### PR TITLE
Fix build errors

### DIFF
--- a/KollektivWidget/ContentView.swift
+++ b/KollektivWidget/ContentView.swift
@@ -244,7 +244,7 @@ struct ContentView: View {
                         TextField("Search stops (e.g., \"jernbanetorget\")", text: $searchQuery)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
                             .onChange(of: searchQuery) { _, _ in 
-                                Task { searchStopsWithDebounce() }
+                                Task { await searchStopsWithDebounce() }
                             }
                         if isSearching { ProgressView().scaleEffect(0.8) }
                     }
@@ -253,7 +253,7 @@ struct ContentView: View {
                             VStack(alignment: .leading, spacing: 4) {
                                 ForEach(searchResults) { result in
                                     Button(action: { 
-                                        Task { selectStop(result) }
+                                        Task { await selectStop(result) }
                                     }) {
                                         VStack(alignment: .leading, spacing: 2) {
                                             Text(result.name)
@@ -310,7 +310,7 @@ struct ContentView: View {
                             VStack(alignment: .leading, spacing: 6) {
                                 ForEach(availableLines.filter { selectedAddTab.matches(line: $0) }) { line in
                                     Button(action: { 
-                                        Task { chooseLine(line) }
+                                        Task { await chooseLine(line) }
                                     }) {
                                         HStack(spacing: 10) {
                                             Image(systemName: symbolName(for: line.transportMode))

--- a/KollektivWidget/EnturAPI.swift
+++ b/KollektivWidget/EnturAPI.swift
@@ -220,8 +220,7 @@ struct EnturAPI {
                     lineName: call.serviceJourney.line.name,
                     destination: call.destinationDisplay.frontText,
                     transportMode: call.serviceJourney.line.transportMode,
-                    transportSubmode: call.serviceJourney.line.transportSubmode,
-
+                    transportSubmode: call.serviceJourney.line.transportSubmode
                 )
                 
                 lines.append(line)


### PR DESCRIPTION
## Fix Swift concurrency build errors

### Summary
Fixes compilation errors that prevented the app from building.

### Changes
- **ContentView.swift**: Added missing `await` keywords when calling `@MainActor` methods from `Task` blocks
  - `searchStopsWithDebounce()`
  - `selectStop()`
  - `chooseLine()`
- **EnturAPI.swift**: Removed trailing comma in `TransitLine` initializer causing syntax error

### Testing
- App builds successfully with `make run`